### PR TITLE
Fix missing is_container_running function and improve Docker server s…

### DIFF
--- a/lib/core.sh
+++ b/lib/core.sh
@@ -160,3 +160,18 @@ handle_error() {
 is_docker_setup() {
     [ "$USE_DOCKER" = true ]
 }
+
+# Function to check if a Docker container is running
+is_container_running() {
+    local container_name=$1
+    if [ -z "$DOCKER_EXEC_PATH" ]; then
+        return 1
+    fi
+    local status
+    status=$("$DOCKER_EXEC_PATH" inspect --format="{{.State.Status}}" "$container_name" 2>/dev/null)
+    if [ "$status" = "running" ]; then
+        return 0
+    else
+        return 1
+    fi
+}

--- a/lib/database.sh
+++ b/lib/database.sh
@@ -14,10 +14,7 @@ ensure_db_is_running() {
         return 0
     fi
 
-    local db_status
-    db_status=$("$DOCKER_EXEC_PATH" inspect --format="{{.State.Status}}" ac-database 2>/dev/null)
-
-    if [ "$db_status" = "running" ]; then
+    if is_container_running "ac-database"; then
         return 0
     fi
 

--- a/lib/server.sh
+++ b/lib/server.sh
@@ -220,8 +220,8 @@ ask_for_update_confirmation() {
 
     local servers_running=false
     if is_docker_setup; then
-        # For Docker setups, we check if the ac-database container is running.
-        if is_container_running "ac-database"; then
+        # For Docker setups, we check if core containers are running.
+        if is_container_running "ac-database" || is_container_running "ac-worldserver" || is_container_running "ac-authserver"; then
             servers_running=true
         fi
     else


### PR DESCRIPTION
…tatus checks

- Implement `is_container_running` in `lib/core.sh` to reliably check Docker container status using `docker inspect`.
- Update `ask_for_update_confirmation` in `lib/server.sh` to check if `ac-database`, `ac-worldserver`, or `ac-authserver` are running before proceeding with updates, as per user requirements.
- Refactor `lib/database.sh` to use the new `is_container_running` function for consistency and better error handling.
- Ensure proper stderr redirection to avoid noisy output when containers don't exist.